### PR TITLE
Feature/bound players slack

### DIFF
--- a/src/clj/react_tutorial_om/events.clj
+++ b/src/clj/react_tutorial_om/events.clj
@@ -21,6 +21,28 @@
        (catch Object _
          (println (:throwable &throw-context) "unexpected error"))))))
 
+
+(defn post-league-bound-players-to-slack [{:keys [best1 best2 worst1 worst2 league]}
+                                          slack-url]
+  (when-not (str/blank? slack-url)
+    (async/thread
+      (try+
+        (client/post slack-url
+                     {:form-params {:text (format "League %s:\n
+                                                  \t\tTop players:\n
+                                                  \t\t\t\t1.- %s\n
+                                                  \t\t\t\t2.- %s\n
+                                                  \t\tBottom players:\n
+                                                  \t\t\t\t1.- %s\n
+                                                  \t\t\t\t2.- %s"
+                                                  (name league) best1 best2 worst1 worst2)}
+                      :content-type :json})
+        (catch [:status 403] {:keys [request-time headers body]}
+          (println "Slack 403 " request-time headers))
+        (catch Object _
+          (println (:throwable &throw-context) "unexpected error")))))
+
+  
 (defn setup-slack-loop [channel prefix slack-url]
   (go-loop []
     (when-let [[topic msg] (<! channel)]

--- a/src/clj/react_tutorial_om/events.clj
+++ b/src/clj/react_tutorial_om/events.clj
@@ -42,13 +42,14 @@
         (catch Object _
           (println (:throwable &throw-context) "unexpected error")))))
 
-  
+
 (defn setup-slack-loop [channel prefix slack-url]
   (go-loop []
     (when-let [[topic msg] (<! channel)]
       (println prefix ": " topic ": " msg)
       (case topic
         :league-match (post-league-result-to-slack msg slack-url)
+        :bound-players (post-league-bound-players-to-slack msg slack-url)
         (println "Unknown topic " topic))
       (recur))))
 


### PR DESCRIPTION
## GOAL
To post on Slack the bound players (top and bottom players of a league) once a match has being played. 
This way they will know how they are performing without going to the actual page.

## APPROACH
* Create a new function that will post to slack these values.
* Add that function to the slack loop.
* Make a test for it.

## ADDITIONAL COMMENTS
* This is an ongoing feature. 
* This PR has been made to allow more fluent Clojure speakers to help on the task.
* All feedback is much appreciated.